### PR TITLE
Feature/iPhone XS Max and iPhone XR Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,12 @@ class DetectDeviceService {
 
   detectIphoneX(){
 	 if( Platform.OS === 'ios' &&
-		 !Platform.isTVOS &&
-		 !Platform.isTVOS &&
-		 (windowSize.height === 812 || windowSize.width === 812)) {
+      !Platform.isTVOS &&
+      !Platform.isTVOS &&
+      (
+        (windowSize.height === 812 || windowSize.width === 812) || // iPhone X and iPhone XS
+        (windowSize.height === 896 || windowSize.width === 896) // iPhone XS Max and XR
+      )) {
 	 	this.isIphoneX = true;
 	 } else {
 	 	this.isIphoneX = false;


### PR DESCRIPTION
Updated `detectIphoneX` function to now support iPhone XS Max and iPhone XR, in addition to the currently support iPhone X and iPhone XS. 

iPhone X and XS in portrait have a height dimension of `812`, while the iPhone XS Max and iPhone XR  have a height dimension of `896`. This means existing apps using this library and utilizing the `isIphoneX` property, will scale correctly on both the iPhone XS Max and iPhone XR with this small change.

<img width="1202" alt="iphone x dimensions" src="https://user-images.githubusercontent.com/1689105/45531330-8d703880-b7ac-11e8-8e22-f907a248d185.png">
